### PR TITLE
[deploy] : 강의 오픈 페이지 강제 새로고침 로직 제거 및 sort 추가

### DIFF
--- a/src/component/BottomSheet/LecturerAttendacneLecture/BottomSheetAttendanceButton.tsx
+++ b/src/component/BottomSheet/LecturerAttendacneLecture/BottomSheetAttendanceButton.tsx
@@ -1,5 +1,4 @@
 import { ButtonSet, Button } from "@ui/components";
-import { useState } from "react";
 import styled from "styled-components";
 import { changeLectureState } from "@lib/api";
 
@@ -35,12 +34,12 @@ export const BottomSheetAttendanceButton = ({
                                     requestLectureStateChange('CLOSED')
                                         .finally(() => {
                                                 setBottomOpen();
-                                                window.location.reload();})}}>강의 닫기</Button>
+                                                })}}>강의 닫기</Button>
                 <Button varient={'regular'} onClick={() => {
                                     requestLectureStateChange('OPEN')
                                         .finally(() => {
                                                 setBottomOpen();
-                                                window.location.reload();})}}>강의 열기</Button>
+                                                })}}>강의 열기</Button>
             </ButtonSet>
         </Wrapper>
         

--- a/src/component/BottomSheet/StudentAttendace/BottomSheetSAttendanceContent.tsx
+++ b/src/component/BottomSheet/StudentAttendace/BottomSheetSAttendanceContent.tsx
@@ -64,7 +64,7 @@ export const BottomSheetSAttendanceContent = ({lecture, setBottomOpen}: BottomSh
                     alert('출석 성공');
                     setBottomOpen();
                 } else {
-                    alert('출석 가능 시간이 만료되었습니다. 멘토님께 문의하세요!');
+                    alert('출석 실패! 출석번호를 확인해주세요.');
                 }
             });
     }

--- a/src/component/LectureLists/LecturerEnrollment.tsx
+++ b/src/component/LectureLists/LecturerEnrollment.tsx
@@ -21,6 +21,20 @@ export const LecturerEnrollment = ({lecturelist, load} : {
       setCurrentLecture(lecture);
       setModalOpen(true);
     }
+
+    lecturelist?.lectureInfos.sort(
+      function(a, b): number{
+          if(a.lectureId > b.lectureId)
+              return 1
+          if (a.lectureId === b.lectureId){
+              return 0
+          }
+          if(a.lectureId< b.lectureId) {
+              return -1
+          }
+          return 0
+      }
+  )
     return (
         load ?
         lecturelist && lecturelist.lectureInfos.length !== 0 ?

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -2,7 +2,7 @@ import axios, { type AxiosResponse } from "axios";
 import {getHeadersWithToken, removeToken} from "@util/AuthFunctions";
 
 const protocol = `https`;
-const host = `dev-api.imhere.im`;
+const host = `api.imhere.im`;
 const statusString = `?status=`;
 
 // member

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -2,7 +2,7 @@ import axios, { type AxiosResponse } from "axios";
 import {getHeadersWithToken, removeToken} from "@util/AuthFunctions";
 
 const protocol = `https`;
-const host = `api.imhere.im`;
+const host = `dev-api.imhere.im`;
 const statusString = `?status=`;
 
 // member


### PR DESCRIPTION
지금까지 강의를 오픈하면 reload 를 시켜 새로운 강의에 대한 status를 보여주었습니다.
그러나, 이렇게 하게 되면 백엔드에서 오는 redirect 코드를 제대로 수행하지 못하므로 해당 로직을 지워주었습니다.

또한, 강의자 페이지에서 강의가 sort되지 않고 뒤죽박죽 되어 있어, 오름차순으로 소팅하는 로직을 추가했습니다. 